### PR TITLE
fix: database initialization error handling

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -4,8 +4,6 @@ use std::path::Path;
 use crate::database::DatabaseManager;
 
 pub async fn handle_init_command() -> Result<()> {
-    println!("Initializing RetroChat database...");
-
     let db_path = "retrochat.db";
 
     // Check if database already exists
@@ -14,6 +12,8 @@ pub async fn handle_init_command() -> Result<()> {
         println!("  Use 'retrochat tui' to launch the interface");
         return Ok(());
     }
+
+    println!("Initializing RetroChat database...");
 
     // Initialize database
     let _db_manager = DatabaseManager::new(db_path)

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -15,9 +15,17 @@ impl DatabaseManager {
 
         // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("Failed to create database directory: {}", parent.display())
-            })?;
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create database directory: {}", parent.display())
+                })?;
+            }
+        }
+
+        // Ensure the database file can be created/opened
+        if !db_path.exists() {
+            std::fs::File::create(&db_path)
+                .with_context(|| format!("Failed to create database file: {}", db_path.display()))?;
         }
 
         // Create SQLite connection string


### PR DESCRIPTION
- Fix error when initializing database without existing file
- Add explicit database file creation before SQLite connection
- Move initialization message after existence check
- Handle empty parent directory path correctly

This fixes the issue where 'retrochat init' would fail with "unable to open database file" error on first run.

🤖 Generated with [Claude Code](https://claude.ai/code)