### PR TITLE
feat: Add Makefile improvements and database configuration

### DIFF
--- a/src/database/config.rs
+++ b/src/database/config.rs
@@ -1,8 +1,17 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
+use crate::env::database as env_vars;
+
 /// Get the default database path in the user's home directory
+/// Can be overridden by RETROCHAT_DB environment variable
 pub fn get_default_db_path() -> Result<PathBuf> {
+    // Check if RETROCHAT_DB environment variable is set
+    if let Ok(db_path) = std::env::var(env_vars::RETROCHAT_DB) {
+        return Ok(PathBuf::from(db_path));
+    }
+
+    // Otherwise use default path
     let home_dir = dirs::home_dir().context("Could not find home directory")?;
     Ok(home_dir.join(".retrochat").join("retrochat.db"))
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -42,6 +42,12 @@ pub mod system {
     pub const HOME: &str = "HOME";
 }
 
+/// Database configuration
+pub mod database {
+    /// Database file path (overrides default ~/.retrochat/retrochat.db)
+    pub const RETROCHAT_DB: &str = "RETROCHAT_DB";
+}
+
 /// Retrospection operation configuration (from specs)
 pub mod retrospection {
     /// Default timeout for operations (seconds)


### PR DESCRIPTION
## Summary

This PR enhances the development workflow with new Makefile targets and adds configurable database path support via environment variables.

## Makefile Enhancements

### New Targets

- **`make doctor`**: Check system dependencies
  - ✓ Validates mandatory tools: rustc, cargo (fails if missing)
  - ✓ Validates optional tools: python3 (warns if missing)
  - ✓ Shows version information with clear visual feedback
  - Helpful for onboarding and troubleshooting

- **`make init`**: Initialize retrochat
  - Convenient shorthand for `cargo run -- init`
  - Simplifies setup process

- **`make tui`**: Launch TUI interface
  - Quick access to terminal user interface
  - `cargo run -- tui` shorthand

### Enhanced `make e2e-import`

- Uses isolated test database: `~/.retrochat/retrochat_e2e.db`
- Initializes test database before running imports
- All import commands use `RETROCHAT_DB` environment variable
- Automatically cleans up test database after completion
- Prevents pollution of production database during testing

## Environment Variable Configuration

### Database Path Override (`RETROCHAT_DB`)

- Added `RETROCHAT_DB` to `src/env.rs` (database module)
- Updated `src/database/config.rs` to check environment variable first
- Falls back to default `~/.retrochat/retrochat.db` if not set
- Full backward compatibility maintained
- Follows project pattern of centralized env var management

## Benefits

1. **Developer Experience**: New helper targets improve workflow efficiency
2. **Test Isolation**: E2E tests no longer affect production database
3. **Flexibility**: Database path can be customized via environment variable
4. **Safety**: Automatic cleanup prevents test data accumulation
5. **Consistency**: Follows established project patterns

## Testing

- ✅ All 98 tests pass
- ✅ `make doctor` validates dependencies correctly
- ✅ `make help` displays all new targets
- ✅ Code compiles without errors
- ✅ Makefile syntax validated

## Usage Examples

```bash
# Check system dependencies
make doctor

# Initialize database
make init

# Launch TUI
make tui

# Run E2E tests with isolated database
make e2e-import

# Use custom database path
RETROCHAT_DB=/tmp/test.db cargo run -- init
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)