### PR TITLE
feat: pair tool_use and tool_result messages in TUI display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,10 @@ name = "test_codex_parser"
 path = "tests/unit/test_codex_parser.rs"
 
 [[test]]
+name = "test_message_pairing"
+path = "tests/unit/test_message_pairing.rs"
+
+[[test]]
 name = "test_first_time_setup"
 path = "tests/integration/test_first_time_setup.rs"
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,7 +6,7 @@ pub mod retrospect_request;
 pub mod retrospection;
 
 pub use chat_session::{ChatSession, SessionState};
-pub use message::{Message, MessageRole, ToolCall};
+pub use message::{Message, MessageRole, ToolCall, ToolResult, ToolUse};
 pub use project::Project;
 pub use provider::{ParserType, Provider, ProviderConfig, ProviderRegistry};
 pub use retrospect_request::{

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -19,9 +19,9 @@ pub use import_service::{
 };
 pub use parser_service::ParserService;
 pub use query_service::{
-    DateRange, QueryService, SearchRequest, SearchResponse, SearchResult, SessionDetailRequest,
-    SessionDetailResponse, SessionFilters, SessionSummary, SessionsQueryRequest,
-    SessionsQueryResponse,
+    DateRange, MessageGroup, QueryService, SearchRequest, SearchResponse, SearchResult,
+    SessionDetailRequest, SessionDetailResponse, SessionFilters, SessionSummary,
+    SessionsQueryRequest, SessionsQueryResponse,
 };
 pub use retrospection_service::{
     AnalysisData, RetrospectionCleanupHandler, RetrospectionService, SessionMetrics,

--- a/tests/unit/test_message_pairing.rs
+++ b/tests/unit/test_message_pairing.rs
@@ -1,0 +1,189 @@
+use chrono::Utc;
+use retrochat::models::{Message, MessageRole, ToolResult, ToolUse};
+use retrochat::services::MessageGroup;
+use serde_json::json;
+use uuid::Uuid;
+
+/// Helper function to create a test message
+fn create_message(session_id: Uuid, role: MessageRole, content: &str, sequence: u32) -> Message {
+    Message::new(session_id, role, content.to_string(), Utc::now(), sequence)
+}
+
+/// Helper function to create a test tool use
+fn create_tool_use(id: &str, name: &str) -> ToolUse {
+    ToolUse {
+        id: id.to_string(),
+        name: name.to_string(),
+        input: json!({}),
+        raw: json!({}),
+    }
+}
+
+/// Helper function to create a test tool result
+fn create_tool_result(tool_use_id: &str, content: &str, is_error: bool) -> ToolResult {
+    ToolResult {
+        tool_use_id: tool_use_id.to_string(),
+        content: content.to_string(),
+        is_error,
+        details: None,
+        raw: json!({}),
+    }
+}
+
+#[test]
+fn test_pair_tool_messages_with_separate_messages() {
+    let session_id = Uuid::new_v4();
+
+    // Message 1: User message
+    let msg1 = create_message(session_id, MessageRole::User, "Run ls command", 1);
+
+    // Message 2: Assistant with tool use
+    let mut msg2 = create_message(session_id, MessageRole::Assistant, "Running command", 2);
+    let tool_use = create_tool_use("tool_1", "Bash");
+    msg2 = msg2.with_tool_uses(vec![tool_use]);
+
+    // Message 3: Tool result (separate message)
+    let mut msg3 = create_message(session_id, MessageRole::Assistant, "[Tool Result]", 3);
+    let tool_result = create_tool_result("tool_1", "file1.txt\nfile2.txt", false);
+    msg3 = msg3.with_tool_results(vec![tool_result]);
+
+    // Message 4: Assistant response
+    let msg4 = create_message(session_id, MessageRole::Assistant, "Here are the files", 4);
+
+    let messages = vec![msg1.clone(), msg2.clone(), msg3.clone(), msg4.clone()];
+    let groups = MessageGroup::pair_tool_messages(messages);
+
+    // Expected: [Single(msg1), ToolPair(msg2, msg3), Single(msg4)]
+    assert_eq!(groups.len(), 3);
+
+    match &groups[0] {
+        MessageGroup::Single(m) => assert_eq!(m.sequence_number, 1),
+        _ => panic!("Expected Single for first message"),
+    }
+
+    match &groups[1] {
+        MessageGroup::ToolPair {
+            tool_use_message,
+            tool_result_message,
+        } => {
+            assert_eq!(tool_use_message.sequence_number, 2);
+            assert_eq!(tool_result_message.sequence_number, 3);
+        }
+        _ => panic!("Expected ToolPair for messages 2 and 3"),
+    }
+
+    match &groups[2] {
+        MessageGroup::Single(m) => assert_eq!(m.sequence_number, 4),
+        _ => panic!("Expected Single for last message"),
+    }
+}
+
+#[test]
+fn test_pair_tool_messages_with_same_message() {
+    let session_id = Uuid::new_v4();
+
+    // Message with both tool use and tool result (already paired in the message)
+    let mut msg = create_message(session_id, MessageRole::Assistant, "Running command", 1);
+    let tool_use = create_tool_use("tool_1", "Bash");
+    let tool_result = create_tool_result("tool_1", "output", false);
+    msg = msg.with_tool_uses(vec![tool_use]);
+    msg = msg.with_tool_results(vec![tool_result]);
+
+    let messages = vec![msg.clone()];
+    let groups = MessageGroup::pair_tool_messages(messages);
+
+    // Expected: [Single(msg)] - already paired within the message
+    assert_eq!(groups.len(), 1);
+    match &groups[0] {
+        MessageGroup::Single(_) => {} // Expected
+        _ => panic!("Expected Single for message with both tool_use and tool_result"),
+    }
+}
+
+#[test]
+fn test_pair_tool_messages_no_matching_tool_result() {
+    let session_id = Uuid::new_v4();
+
+    // Message with tool use but no matching tool result
+    let mut msg1 = create_message(session_id, MessageRole::Assistant, "Running command", 1);
+    let tool_use = create_tool_use("tool_1", "Bash");
+    msg1 = msg1.with_tool_uses(vec![tool_use]);
+
+    // Next message has tool result with different ID
+    let mut msg2 = create_message(session_id, MessageRole::Assistant, "[Tool Result]", 2);
+    let tool_result = create_tool_result("tool_2", "output", false);
+    msg2 = msg2.with_tool_results(vec![tool_result]);
+
+    let messages = vec![msg1.clone(), msg2.clone()];
+    let groups = MessageGroup::pair_tool_messages(messages);
+
+    // Expected: [Single(msg1), Single(msg2)] - IDs don't match
+    assert_eq!(groups.len(), 2);
+    match &groups[0] {
+        MessageGroup::Single(m) => assert_eq!(m.sequence_number, 1),
+        _ => panic!("Expected Single for first message"),
+    }
+    match &groups[1] {
+        MessageGroup::Single(m) => assert_eq!(m.sequence_number, 2),
+        _ => panic!("Expected Single for second message"),
+    }
+}
+
+#[test]
+fn test_pair_tool_messages_multiple_pairs() {
+    let session_id = Uuid::new_v4();
+
+    // First pair
+    let mut msg1 = create_message(session_id, MessageRole::Assistant, "Running ls", 1);
+    msg1 = msg1.with_tool_uses(vec![create_tool_use("tool_1", "Bash")]);
+
+    let mut msg2 = create_message(session_id, MessageRole::Assistant, "[Tool Result]", 2);
+    msg2 = msg2.with_tool_results(vec![create_tool_result("tool_1", "file1.txt", false)]);
+
+    // Second pair
+    let mut msg3 = create_message(session_id, MessageRole::Assistant, "Running pwd", 3);
+    msg3 = msg3.with_tool_uses(vec![create_tool_use("tool_2", "Bash")]);
+
+    let mut msg4 = create_message(session_id, MessageRole::Assistant, "[Tool Result]", 4);
+    msg4 = msg4.with_tool_results(vec![create_tool_result("tool_2", "/home/user", false)]);
+
+    let messages = vec![msg1, msg2, msg3, msg4];
+    let groups = MessageGroup::pair_tool_messages(messages);
+
+    // Expected: [ToolPair(1,2), ToolPair(3,4)]
+    assert_eq!(groups.len(), 2);
+
+    for (i, group) in groups.iter().enumerate() {
+        match group {
+            MessageGroup::ToolPair { .. } => {} // Expected
+            _ => panic!("Expected ToolPair for pair {}", i + 1),
+        }
+    }
+}
+
+#[test]
+fn test_pair_tool_messages_empty_list() {
+    let messages: Vec<Message> = vec![];
+    let groups = MessageGroup::pair_tool_messages(messages);
+    assert_eq!(groups.len(), 0);
+}
+
+#[test]
+fn test_pair_tool_messages_no_tools() {
+    let session_id = Uuid::new_v4();
+
+    let msg1 = create_message(session_id, MessageRole::User, "Hello", 1);
+    let msg2 = create_message(session_id, MessageRole::Assistant, "Hi there", 2);
+
+    let messages = vec![msg1, msg2];
+    let groups = MessageGroup::pair_tool_messages(messages);
+
+    // Expected: [Single(msg1), Single(msg2)]
+    assert_eq!(groups.len(), 2);
+    for group in &groups {
+        match group {
+            MessageGroup::Single(_) => {} // Expected
+            _ => panic!("Expected all Single for messages without tools"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Option 3 from issue #36 by pairing tool_use and tool_result messages at the TUI level for improved viewing experience.

## Changes

- **Service Layer**: Add `MessageGroup` enum to represent single or paired messages
- **Pairing Logic**: Implement `MessageGroup::pair_tool_messages()` to intelligently pair consecutive tool_use/tool_result messages based on matching `tool_use_id`
- **TUI Display**: Update session detail rendering to show paired tool messages together with visual indicators (using tree-style connectors: ├─ and │)
- **Tests**: Add comprehensive unit tests for message pairing logic (6 test cases)
- **Exports**: Export `ToolUse` and `ToolResult` from models module for test access

## Implementation Details

### Pairing Algorithm
The `MessageGroup::pair_tool_messages()` method:
1. Iterates through messages sequentially
2. Detects messages with tool_uses but no tool_results
3. Checks if the next message has matching tool_results (via tool_use_id)
4. Creates a ToolPair group when match is found, otherwise creates Single groups

### Visual Display
Tool pairs are rendered with:
- Unified header showing both sequence numbers: `[HH:MM:SS] Assistant → Tool Execution (seq1, seq2)`
- Tree-style indicators: `├─ Tool Execution & Result`
- Indented tool output: `│  [tool output]`
- Combined token counts from both messages

## Design Decision Rationale

Chose **Option 3 (TUI level pairing)** because:
- ✅ Respects architecture layering: Repo ← Service ← TUI
- ✅ No database migration needed (tool_use_id already provides relationship)
- ✅ Flexible display logic without affecting data integrity
- ✅ Follows project guideline: "Keep output handling separate from core business logic"
- ✅ Pure display concern - data model correctly reflects reality (they ARE separate messages)

## Test Plan

- [x] Unit tests pass (6/6 test cases)
- [x] All integration tests pass
- [x] Full CI validation passes (fmt + clippy + tests)
- [x] Manual testing with real tool_use/tool_result patterns

## Related Issues

Closes #36

Generated with [Claude Code](https://claude.com/claude-code)