### PR TITLE
feat: add time range filtering to search command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -124,6 +124,12 @@ pub enum Commands {
         /// Maximum number of results (default: 20)
         #[arg(short, long)]
         limit: Option<i32>,
+        /// Messages since this time (e.g., "7 days ago", "2024-10-01", "yesterday")
+        #[arg(long)]
+        since: Option<String>,
+        /// Messages until this time (e.g., "now", "2024-10-31", "today")
+        #[arg(long)]
+        until: Option<String>,
     },
     /// [Alias for 'retrospect execute'] Review and analyze a chat session
     Review {
@@ -175,6 +181,12 @@ pub enum QueryCommands {
         /// Maximum number of results (default: 20)
         #[arg(short, long)]
         limit: Option<i32>,
+        /// Messages since this time (e.g., "7 days ago", "2024-10-01", "yesterday")
+        #[arg(long)]
+        since: Option<String>,
+        /// Messages until this time (e.g., "now", "2024-10-31", "today")
+        #[arg(long)]
+        until: Option<String>,
     },
     /// Query messages by time range
     Timeline {
@@ -269,9 +281,12 @@ impl Cli {
                     QueryCommands::Session { session_id } => {
                         query::handle_session_detail_command(session_id).await
                     }
-                    QueryCommands::Search { query, limit } => {
-                        query::handle_search_command(query, limit).await
-                    }
+                    QueryCommands::Search {
+                        query,
+                        limit,
+                        since,
+                        until,
+                    } => query::handle_search_command(query, limit, since, until).await,
                     QueryCommands::Timeline {
                         since,
                         until,
@@ -343,9 +358,12 @@ impl Cli {
                     }
                 }
                 Commands::Stats => analytics::handle_insights_command().await,
-                Commands::Search { query, limit } => {
-                    query::handle_search_command(query, limit).await
-                }
+                Commands::Search {
+                    query,
+                    limit,
+                    since,
+                    until,
+                } => query::handle_search_command(query, limit, since, until).await,
                 Commands::Review { session_id } => {
                     // For now, delegate to retrospect execute
                     // TODO: Could make this more interactive

--- a/src/database/message_repo.rs
+++ b/src/database/message_repo.rs
@@ -199,6 +199,71 @@ impl MessageRepository {
         Ok(messages)
     }
 
+    pub async fn search_content_with_time_filters(
+        &self,
+        query: &str,
+        session_id: Option<&Uuid>,
+        role: Option<&str>,
+        from: Option<DateTime<Utc>>,
+        to: Option<DateTime<Utc>>,
+        limit: Option<i64>,
+    ) -> AnyhowResult<Vec<Message>> {
+        let limit = limit.unwrap_or(100);
+
+        let mut sql = r#"
+            SELECT m.id, m.session_id, m.role, m.content, m.timestamp,
+                   m.token_count, m.tool_calls, m.metadata, m.sequence_number,
+                   m.tool_uses, m.tool_results
+            FROM messages m
+            JOIN messages_fts fts ON m.rowid = fts.rowid
+            WHERE messages_fts MATCH ?
+        "#
+        .to_string();
+
+        let mut params = vec![query.to_string()];
+
+        if let Some(session_id) = session_id {
+            sql.push_str(" AND m.session_id = ?");
+            params.push(session_id.to_string());
+        }
+
+        if let Some(role) = role {
+            sql.push_str(" AND m.role = ?");
+            params.push(role.to_string());
+        }
+
+        if let Some(from_time) = from {
+            sql.push_str(" AND m.timestamp >= ?");
+            params.push(from_time.to_rfc3339());
+        }
+
+        if let Some(to_time) = to {
+            sql.push_str(" AND m.timestamp <= ?");
+            params.push(to_time.to_rfc3339());
+        }
+
+        sql.push_str(" ORDER BY fts.rank LIMIT ?");
+        params.push(limit.to_string());
+
+        let mut query_builder = sqlx::query(&sql);
+        for param in &params {
+            query_builder = query_builder.bind(param);
+        }
+
+        let rows = query_builder
+            .fetch_all(&self.pool)
+            .await
+            .context("Failed to search messages with time filters")?;
+
+        let mut messages = Vec::new();
+        for row in rows {
+            let message = self.row_to_message(&row)?;
+            messages.push(message);
+        }
+
+        Ok(messages)
+    }
+
     pub async fn count_by_session(&self, session_id: &Uuid) -> AnyhowResult<i64> {
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE session_id = ?")
             .bind(session_id.to_string())

--- a/src/utils/time_parser.rs
+++ b/src/utils/time_parser.rs
@@ -152,4 +152,47 @@ mod tests {
         let result = parse_time_spec("invalid input");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_parse_hours_ago() {
+        let result = parse_time_spec("2 hours ago");
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        let expected = Utc::now() - Duration::hours(2);
+        // Allow 2 second tolerance
+        assert!((dt.timestamp() - expected.timestamp()).abs() < 2);
+    }
+
+    #[test]
+    fn test_parse_weeks_ago() {
+        let result = parse_time_spec("2 weeks ago");
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        let expected = Utc::now() - Duration::weeks(2);
+        // Allow 2 second tolerance
+        assert!((dt.timestamp() - expected.timestamp()).abs() < 2);
+    }
+
+    #[test]
+    fn test_parse_today() {
+        let result = parse_time_spec("today");
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        let now = Utc::now();
+        assert_eq!(dt.date_naive(), now.date_naive());
+        assert_eq!(dt.hour(), 0);
+        assert_eq!(dt.minute(), 0);
+    }
+
+    #[test]
+    fn test_parse_plural_units() {
+        // Test plural forms
+        let days_result = parse_time_spec("5 days ago");
+        let hours_result = parse_time_spec("3 hours ago");
+        let minutes_result = parse_time_spec("30 minutes ago");
+
+        assert!(days_result.is_ok());
+        assert!(hours_result.is_ok());
+        assert!(minutes_result.is_ok());
+    }
 }

--- a/tests/contract/test_cli_add_command.rs
+++ b/tests/contract/test_cli_add_command.rs
@@ -80,8 +80,7 @@ fn test_stats_command() {
 
     match stats_cmd {
         Commands::Stats => {
-            // Stats command has no fields
-            assert!(true);
+            // Stats command has no fields, test passes if we match this variant
         }
         _ => panic!("Expected Stats command"),
     }
@@ -92,12 +91,21 @@ fn test_search_command_structure() {
     let search_cmd = Commands::Search {
         query: "test query".to_string(),
         limit: Some(10),
+        since: None,
+        until: None,
     };
 
     match search_cmd {
-        Commands::Search { query, limit } => {
+        Commands::Search {
+            query,
+            limit,
+            since,
+            until,
+        } => {
             assert_eq!(query, "test query");
             assert_eq!(limit, Some(10));
+            assert!(since.is_none());
+            assert!(until.is_none());
         }
         _ => panic!("Expected Search command"),
     }
@@ -108,12 +116,46 @@ fn test_search_command_without_limit() {
     let search_cmd = Commands::Search {
         query: "test".to_string(),
         limit: None,
+        since: None,
+        until: None,
     };
 
     match search_cmd {
-        Commands::Search { query, limit } => {
+        Commands::Search {
+            query,
+            limit,
+            since,
+            until,
+        } => {
             assert_eq!(query, "test");
             assert!(limit.is_none());
+            assert!(since.is_none());
+            assert!(until.is_none());
+        }
+        _ => panic!("Expected Search command"),
+    }
+}
+
+#[test]
+fn test_search_command_with_time_range() {
+    let search_cmd = Commands::Search {
+        query: "test".to_string(),
+        limit: Some(10),
+        since: Some("7 days ago".to_string()),
+        until: Some("now".to_string()),
+    };
+
+    match search_cmd {
+        Commands::Search {
+            query,
+            limit,
+            since,
+            until,
+        } => {
+            assert_eq!(query, "test");
+            assert_eq!(limit, Some(10));
+            assert_eq!(since, Some("7 days ago".to_string()));
+            assert_eq!(until, Some("now".to_string()));
         }
         _ => panic!("Expected Search command"),
     }
@@ -139,8 +181,7 @@ fn test_setup_command() {
 
     match setup_cmd {
         Commands::Setup => {
-            // Setup command has no fields
-            assert!(true);
+            // Setup command has no fields, test passes if we match this variant
         }
         _ => panic!("Expected Setup command"),
     }
@@ -162,7 +203,9 @@ fn test_cli_with_command() {
 
     assert!(cli.command.is_some(), "Command should be present");
     match cli.command {
-        Some(Commands::Stats) => assert!(true),
+        Some(Commands::Stats) => {
+            // Test passes if we match this variant
+        }
         _ => panic!("Expected Stats command"),
     }
 }

--- a/tests/integration/test_setup_wizard.rs
+++ b/tests/integration/test_setup_wizard.rs
@@ -51,9 +51,9 @@ async fn test_run_setup_wizard_structure() {
     // (e.g., using expect-test or similar for CLI testing)
 
     // For now, we just verify the types are correct
-    let _fn_ptr: fn() -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>,
-    > = || Box::pin(async { Ok(()) });
+    type SetupFuture =
+        std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>>;
+    let _fn_ptr: fn() -> SetupFuture = || Box::pin(async { Ok(()) });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `--since` and `--until` flags to the search CLI command for time-based filtering
- Support multiple time formats: timeago, date, datetime, and Unix timestamps
- Reuse existing `time_parser` utility - no new dependencies

## Key Changes

### Time Range Parameters
- **CLI flags**: `--since` and `--until` on both `search` and `query search` commands
- **Supported formats**:
  - Timeago: `"7 days ago"`, `"2 hours ago"`, `"yesterday"`, `"today"`, `"now"`
  - Date: `"2024-10-01"`
  - Datetime: `"2024-10-19T14:23:45Z"` (RFC3339)
  - Unix timestamp: `"@1697328000"`

### Implementation Details

**CLI Layer** (`src/cli/mod.rs`, `src/cli/query.rs`):
- Added optional `since` and `until` string parameters
- Parse using existing `time_parser::parse_time_spec`
- Convert to RFC3339 strings for service layer

**Service Layer** (`src/services/query_service.rs`):
- Parse date range strings to `DateTime<Utc>`
- Pass datetime filters to repository

**Repository Layer** (`src/database/message_repo.rs`):
- New method: `search_content_with_time_filters`
- SQL filters: `m.timestamp >= ?` and `m.timestamp <= ?`
- Maintains FTS search performance

### Testing

- ✅ Added time parser tests for hours, weeks, today, plural units
- ✅ Added integration tests for datetime ranges and recent searches
- ✅ Updated CLI command structure tests
- ✅ All existing tests passing
- ✅ Clippy clean with `-D warnings`

## Usage Examples

```bash
# Search messages from the last 7 days
retrochat search "machine learning" --since "7 days ago"

# Search with specific date range
retrochat search "bug fix" --since "2024-10-01" --until "2024-10-31"

# Search with timeago format
retrochat search "performance" --since "yesterday" --until "now"

# Search with datetime (RFC3339)
retrochat search "error" --since "2024-10-19T14:23:45Z"

# Only specify one bound
retrochat search "todo" --since "1 week ago"  # All messages since last week
retrochat search "completed" --until "yesterday"  # All messages up to yesterday
```

## Help Text

```
$ retrochat search --help
[Alias for 'query search'] Search messages by content

Usage: retrochat search [OPTIONS] <QUERY>

Arguments:
  <QUERY>  Search query

Options:
  -l, --limit <LIMIT>  Maximum number of results (default: 20)
      --since <SINCE>  Messages since this time (e.g., "7 days ago", "2024-10-01", "yesterday")
      --until <UNTIL>  Messages until this time (e.g., "now", "2024-10-31", "today")
  -h, --help           Print help
```

## Technical Notes

- **No new dependencies**: Reuses existing `time_parser` utility and `chrono` crate
- **Backward compatible**: Both flags are optional, existing searches work unchanged
- **Layer adherence**: Follows repo → service → CLI architecture pattern
- **Performance**: Time filtering uses indexed timestamp column in SQL

## Test Plan
- [x] Unit tests for time parsing (hours, weeks, plural units)
- [x] Integration tests for search with time ranges
- [x] CLI command structure tests
- [x] Manual testing with various time formats
- [x] Verify help text displays correctly
- [x] Run full test suite: `cargo test`
- [x] Run clippy: `cargo clippy --all-targets -- -D warnings`
- [x] Format check: `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)