### PR TITLE
fix: Improve TUI key binding consistency and clean up UI hints

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -203,7 +203,7 @@ impl App {
             // Auto-refresh data periodically - frequent refresh for active views
             let refresh_interval = match self.state.mode {
                 AppMode::SessionList => Duration::from_secs(3), // Refresh every 3 seconds for session list to catch status changes
-                AppMode::SessionDetail => Duration::from_secs(5), // Refresh every 5 seconds for session detail
+                AppMode::SessionDetail => Duration::from_secs(3), // Refresh every 3 seconds for session detail
                 _ => Duration::from_secs(30), // Normal 30 second refresh for other views
             };
 
@@ -523,13 +523,12 @@ impl App {
     fn render_footer(&self, f: &mut Frame, area: Rect) {
         let key_hints = match self.state.mode {
             AppMode::SessionList => {
-                "↑/↓: Navigate | Enter: View | a: Analytics | ?: Help | q: Quit | Auto-refreshes every 5s"
+                "↑/↓: Navigate | Enter: View | a: Analytics | ?: Help | q: Quit"
             }
-            AppMode::SessionDetail => {
-                "↑/↓: Scroll | w: Wrap | Esc: Back | ?: Help | q: Quit | Auto-refreshes every 5s"
-            }
+            AppMode::SessionDetail => "↑/↓: Scroll | Esc: Back | ?: Help | q: Quit",
             AppMode::Help => "Any key: Close Help",
-        }.to_string();
+        }
+        .to_string();
 
         // Processing status removed from bottom area
 
@@ -557,16 +556,19 @@ impl App {
             Line::from(""),
             Line::from("Session List:"),
             Line::from("  ↑/↓            - Navigate sessions"),
+            Line::from("  Page Up/Down   - Fast navigation"),
+            Line::from("  Home/End       - Jump to start/end"),
             Line::from("  Enter          - View session details"),
+            Line::from("  s              - Change sort field"),
+            Line::from("  o              - Toggle sort order"),
             Line::from("  a              - Start analytics analysis"),
-            Line::from("  (Auto-refreshes every 5 seconds)"),
             Line::from(""),
             Line::from("Session Detail:"),
             Line::from("  ↑/↓            - Scroll messages"),
             Line::from("  Page Up/Down   - Fast scroll"),
             Line::from("  Home/End       - Jump to start/end"),
-            Line::from("  w              - Toggle word wrap"),
-            Line::from("  (Auto-refreshes every 5 seconds)"),
+            Line::from("  d              - Toggle tool details"),
+            Line::from("  a              - Toggle analytics view"),
         ];
 
         let dialog = Dialog::new(DialogType::Help, content).size(80, 70);

--- a/src/tui/session_detail.rs
+++ b/src/tui/session_detail.rs
@@ -200,7 +200,7 @@ impl SessionDetailWidget {
             };
 
             format!(
-                "Provider: {} | Project: {} | Messages: {} | Tokens: {} | Started: {} | Status: {}{} | Keys: 'd'=tool-details 'a'=analytics",
+                "Provider: {} | Project: {} | Messages: {} | Tokens: {} | Started: {} | Status: {}{}",
                 session.provider,
                 project_str,
                 session.message_count,

--- a/src/tui/session_list.rs
+++ b/src/tui/session_list.rs
@@ -132,12 +132,16 @@ impl SessionListWidget {
             "Loading sessions...".to_string()
         } else {
             format!(
-                "Sessions: {} | Page: {}/{} | Sort: {} {} | Press 's' to change sort, 'o' to toggle order",
+                "Sessions: {} | Page: {}/{} | Sort: {} {}",
                 self.state.total_count,
                 self.state.page,
                 total_pages.max(1),
                 self.state.sort_by.as_str(),
-                if matches!(self.state.sort_order, SortOrder::Ascending) { "↑" } else { "↓" }
+                if matches!(self.state.sort_order, SortOrder::Ascending) {
+                    "↑"
+                } else {
+                    "↓"
+                }
             )
         };
 


### PR DESCRIPTION
## Summary
- Remove unimplemented 'w' key for word wrap from footer and help screen
- Standardize refresh rates to 3s for both SessionList and SessionDetail modes
- Remove auto-refresh rate information from all UI elements (footer and help)
- Consolidate key hints to footer only (removed from session headers)
- Enhanced help screen to show all available keys (s, o, d, a, Page Up/Down, Home/End)

## Changes
- **app.rs**: Updated footer hints, help screen, and refresh interval for SessionDetail
- **session_list.rs**: Removed key hints from header
- **session_detail.rs**: Removed key hints from header

## Test plan
- All tests pass (192 tests)
- Code formatting verified with `cargo fmt`
- Linting verified with `cargo clippy -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)