### PR TITLE
Unify analytics loading indicators to use animated spinner

### DIFF
--- a/src/tui/session_list.rs
+++ b/src/tui/session_list.rs
@@ -243,7 +243,7 @@ impl SessionListWidget {
                     .add_modifier(Modifier::BOLD),
             ),
             Some(OperationStatus::Pending) => Span::styled(
-                "⋯ ",
+                format!("{spinner_char} "),
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary
Replaced the static ellipsis indicator for analytics Pending status with the animated spinner to create a more consistent user experience.

## Changes
- Modified `src/tui/session_list.rs` to use `format!("{spinner_char} ")` instead of static `"⋯ "` for `OperationStatus::Pending`
- Both Pending and Running states now show the same animated spinner (⠋⠙⠹⠸⠼⠴⠦⠧)
- States remain visually distinct through their colors:
  - Pending: Yellow animated spinner
  - Running: Light Blue animated spinner

## Test plan
- [x] Code compiles without errors
- [x] Code formatting passes (`cargo fmt`)
- [x] Clippy passes with strict warnings (`cargo clippy -- -D warnings`)
- [ ] Manual testing: Trigger analytics on a session and verify the Pending status shows an animated spinner

Generated with [Claude Code](https://claude.com/claude-code)