### PR TITLE
feat: Add toggle for thinking messages in session detail view

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -553,6 +553,7 @@ impl App {
             Line::from("  Home/End       - Jump to start/end"),
             Line::from("  d              - Toggle tool details"),
             Line::from("  a              - Toggle analytics view"),
+            Line::from("  t              - Toggle thinking messages"),
         ];
 
         let dialog = Dialog::new(DialogType::Help, content).size(80, 70);

--- a/src/tui/session_detail.rs
+++ b/src/tui/session_detail.rs
@@ -153,6 +153,16 @@ impl SessionDetailWidget {
                 // A: Toggle analytics panel
                 self.state.toggle_analytics();
             }
+            KeyCode::Char('t') => {
+                // T: Toggle thinking messages visibility
+                self.state.toggle_thinking();
+                // Clamp scroll position if it's now out of bounds
+                let max_scroll = self.get_max_scroll();
+                if self.state.current_scroll > max_scroll {
+                    self.state.current_scroll = max_scroll;
+                }
+                self.update_scroll_state();
+            }
             _ => {}
         }
         Ok(())
@@ -283,8 +293,20 @@ impl SessionDetailWidget {
     fn calculate_message_lines(&self, width: usize) -> Vec<Line<'_>> {
         let mut lines = Vec::new();
 
+        // Filter out thinking messages if hidden
+        let messages = if self.state.show_thinking {
+            self.state.messages.clone()
+        } else {
+            self.state
+                .messages
+                .iter()
+                .filter(|msg| !msg.is_thinking())
+                .cloned()
+                .collect()
+        };
+
         // Pair tool_use and tool_result messages
-        let message_groups = MessageGroup::pair_tool_messages(self.state.messages.clone());
+        let message_groups = MessageGroup::pair_tool_messages(messages);
 
         for (group_idx, group) in message_groups.iter().enumerate() {
             // Add separator between groups (except for first)

--- a/src/tui/state/session_detail_state.rs
+++ b/src/tui/state/session_detail_state.rs
@@ -28,6 +28,8 @@ pub struct SessionDetailState {
     pub show_tool_details: bool,
     /// Whether to show analytics panel
     pub show_analytics: bool,
+    /// Whether to show thinking/reasoning messages
+    pub show_thinking: bool,
     /// Last known viewport height for messages (used for scroll calculations)
     pub viewport_height: usize,
     /// Last known viewport height for analytics (used for scroll calculations)
@@ -49,6 +51,7 @@ impl SessionDetailState {
             loading: false,
             show_tool_details: false,
             show_analytics: false,
+            show_thinking: true,           // Show thinking messages by default
             viewport_height: 20,           // Default fallback
             analytics_viewport_height: 20, // Default fallback
         }
@@ -127,6 +130,11 @@ impl SessionDetailState {
         self.show_analytics = !self.show_analytics;
     }
 
+    /// Toggle thinking messages visibility
+    pub fn toggle_thinking(&mut self) {
+        self.show_thinking = !self.show_thinking;
+    }
+
     /// Update analytics data
     pub fn update_analytics(&mut self, analytics: Option<SessionAnalytics>) {
         self.analytics = analytics;
@@ -198,6 +206,7 @@ mod tests {
         assert_eq!(state.current_scroll, 0);
         assert!(!state.show_tool_details);
         assert!(!state.loading);
+        assert!(state.show_thinking); // Thinking messages shown by default
     }
 
     #[test]
@@ -255,6 +264,18 @@ mod tests {
 
         state.scroll_page_up(page_size);
         assert_eq!(state.current_scroll, 10);
+    }
+
+    #[test]
+    fn test_toggle_thinking() {
+        let mut state = SessionDetailState::new();
+        assert!(state.show_thinking); // Default is true
+
+        state.toggle_thinking();
+        assert!(!state.show_thinking); // Toggled to false
+
+        state.toggle_thinking();
+        assert!(state.show_thinking); // Toggled back to true
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add 't' key binding to toggle visibility of AI thinking/reasoning messages in TUI session detail
- Implement state management with show_thinking field (defaults to true)
- Filter thinking messages from display when toggle is off
- Update scroll indicator position when toggling to reflect content size changes

## Implementation Details

The toggle feature includes:
- New `show_thinking` boolean state field in SessionDetailState
- `toggle_thinking()` method to switch visibility
- Message filtering in `calculate_message_lines()` based on state
- Scroll position clamping to prevent out-of-bounds scrolling
- Scroll state refresh to update indicator position

## Test Plan

- [x] Unit tests pass for toggle_thinking state method
- [x] All existing tests continue to pass (193 tests)
- [x] Clippy checks pass with -D warnings
- [x] Code formatted with rustfmt

Manual testing:
- [ ] Open TUI and navigate to a session with thinking messages
- [ ] Press 't' to hide thinking messages - verify they disappear
- [ ] Press 't' again to show them - verify they reappear
- [ ] Test scrolling behavior after toggling
- [ ] Verify scroll indicator updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)