### PR TITLE
Add CLI command to export session as JSON

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,6 +78,15 @@ pub enum Commands {
         session_id: String,
     },
 
+    /// Export a session transcript to JSON file
+    ExportSession {
+        /// Session ID to export
+        session_id: String,
+        /// Output file path (prints to stdout if not specified)
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+
     /// Search messages by content
     Search {
         /// Search query
@@ -298,6 +307,10 @@ impl Cli {
 
                 Commands::Show { session_id } => {
                     query::handle_session_detail_command(session_id).await
+                }
+
+                Commands::ExportSession { session_id, output } => {
+                    query::handle_export_session_command(session_id, output).await
                 }
 
                 Commands::Search {

--- a/src/services/analytics/data_collector.rs
+++ b/src/services/analytics/data_collector.rs
@@ -54,7 +54,8 @@ pub async fn collect_qualitative_data(
 // =============================================================================
 
 /// Builds a JSON string representation of the session transcript with embedded tool uses.
-fn build_session_transcript(
+/// This is the public API for exporting session transcripts.
+pub fn build_session_transcript(
     messages: &[Message],
     tool_operations: &[ToolOperation],
     session: &ChatSession,


### PR DESCRIPTION
This adds a new CLI command `export-session` that exports a specific session to JSON format using the build_session_transcript function.

- Make build_session_transcript public in data_collector.rs
- Add ExportSession command variant to CLI Commands enum
- Implement handle_export_session_command handler in query.rs
- Supports output to file (--output) or stdout