### PR TITLE
feat: add analytics toggle hint to session detail footer

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -509,7 +509,7 @@ impl App {
             AppMode::SessionList => {
                 "↑/↓: Navigate | Enter: View | a: Analytics | ?: Help | q: Quit"
             }
-            AppMode::SessionDetail => "↑/↓: Scroll | Esc: Back | ?: Help | q: Quit",
+            AppMode::SessionDetail => "↑/↓: Scroll | a: Toggle Analytics | Esc: Back | ?: Help | q: Quit",
             AppMode::Help => "Any key: Close Help",
         }
         .to_string();


### PR DESCRIPTION
## Changes
- Add 'a: Toggle Analytics' keyboard shortcut hint to session detail footer
- Improves discoverability of analytics toggle feature in TUI

## Description
This PR adds a keyboard shortcut hint in the session detail footer to inform users about the 'a' key toggle for analytics view. This improves the user experience by making the feature more discoverable.