### PR TITLE
feat: add MCP server for AI assistant integration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ tc = "test -p retrochat-core --verbose"
 tt = "test -p retrochat-tui --verbose"
 tcli = "test -p retrochat-cli --verbose"
 tgui = "test -p retrochat-gui --verbose"
+tmcp = "test -p retrochat-mcp --verbose"
 
 # Build aliases
 c = "check --workspace --verbose"
@@ -21,6 +22,7 @@ core = "run -p retrochat-core"
 cli = "run -p retrochat-cli"
 tui = "run -p retrochat-cli"  # TUI is embedded in CLI
 gui = "run -p retrochat-gui"
+mcp = "run -p retrochat-mcp"
 
 # Clean commands
 clean-all = "clean --workspace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,6 +3596,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -4468,6 +4483,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "retrochat-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "retrochat-core",
+ "rmcp",
+ "schemars 1.1.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "retrochat-tui"
 version = "0.1.0"
 dependencies = [
@@ -4552,6 +4585,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef03779cccab8337dd8617c53fce5c98ec21794febc397531555472ca28f8c3"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4746,7 +4814,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4771,10 +4839,13 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.1.0",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -4782,6 +4853,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6501,10 +6584,14 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/retrochat-tui",
     "crates/retrochat-cli",
     "crates/retrochat-gui",
+    "crates/retrochat-mcp",
 ]
 resolver = "2"
 
@@ -63,6 +64,10 @@ log = "0.4.28"
 # System
 atty = "0.2"
 rusqlite = { version = "0.30", features = ["bundled", "backup"] }
+
+# MCP
+rmcp = { version = "0.11", features = ["server", "macros", "transport-io"] }
+schemars = { version = "1.0", features = ["chrono04", "uuid1"] }
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/retrochat-mcp/Cargo.toml
+++ b/crates/retrochat-mcp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "retrochat-mcp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "MCP server for RetroChat - exposes chat session query and analytics via Model Context Protocol"
+
+[[bin]]
+name = "retrochat-mcp"
+path = "src/main.rs"
+
+[dependencies]
+retrochat-core = { path = "../retrochat-core" }
+
+# MCP
+rmcp = { workspace = true }
+schemars = { workspace = true }
+
+# Async & Core
+tokio = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/crates/retrochat-mcp/src/error.rs
+++ b/crates/retrochat-mcp/src/error.rs
@@ -1,0 +1,71 @@
+//! Error handling for MCP server
+//!
+//! Provides conversion utilities from retrochat errors to MCP protocol errors.
+
+use rmcp::ErrorData as McpError;
+
+/// Convert an anyhow error to an MCP internal error
+pub fn to_mcp_error(err: anyhow::Error) -> McpError {
+    McpError::internal_error(err.to_string(), None)
+}
+
+/// Create an MCP invalid params error
+pub fn validation_error(msg: &str) -> McpError {
+    McpError::invalid_params(msg.to_string(), None)
+}
+
+/// Create an MCP not found error
+pub fn not_found_error(msg: &str) -> McpError {
+    McpError::internal_error(format!("Not found: {}", msg), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::ErrorCode;
+
+    #[test]
+    fn test_anyhow_error_to_mcp_error() {
+        let err = anyhow::anyhow!("Database connection failed");
+        let mcp_err = to_mcp_error(err);
+
+        assert_eq!(mcp_err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(mcp_err.message.contains("Database connection failed"));
+    }
+
+    #[test]
+    fn test_validation_error() {
+        let err = validation_error("Invalid UUID format");
+
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(err.message, "Invalid UUID format");
+    }
+
+    #[test]
+    fn test_not_found_error() {
+        let err = not_found_error("Session with ID abc123");
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Not found"));
+        assert!(err.message.contains("Session with ID abc123"));
+    }
+
+    #[test]
+    fn test_nested_error_conversion() {
+        // Test with a nested error chain
+        let inner_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let outer_err = anyhow::anyhow!(inner_err).context("Failed to read configuration");
+        let mcp_err = to_mcp_error(outer_err);
+
+        assert_eq!(mcp_err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(mcp_err.message.contains("Failed to read configuration"));
+    }
+
+    #[test]
+    fn test_error_message_formatting() {
+        let err = validation_error("Expected format: YYYY-MM-DD, got: invalid-date");
+
+        assert!(err.message.contains("YYYY-MM-DD"));
+        assert!(err.message.contains("invalid-date"));
+    }
+}

--- a/crates/retrochat-mcp/src/lib.rs
+++ b/crates/retrochat-mcp/src/lib.rs
@@ -1,0 +1,10 @@
+//! RetroChat MCP Server
+//!
+//! A Model Context Protocol server that exposes RetroChat's chat session
+//! query and analytics capabilities to AI assistants.
+
+pub mod error;
+pub mod server;
+
+// Re-exports for convenience
+pub use server::*;

--- a/crates/retrochat-mcp/src/main.rs
+++ b/crates/retrochat-mcp/src/main.rs
@@ -1,0 +1,57 @@
+//! RetroChat MCP Server
+//!
+//! A Model Context Protocol server that exposes RetroChat's chat session
+//! query and analytics capabilities to AI assistants.
+
+use retrochat_mcp::RetroChatMcpServer;
+use rmcp::transport::stdio;
+use rmcp::ServiceExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging to stderr (won't interfere with stdio transport)
+    // Use RUST_LOG environment variable to control log level
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr) // Log to stderr, not stdout
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_file(false)
+                .with_line_number(false),
+        )
+        .init();
+
+    tracing::info!(
+        "Starting RetroChat MCP Server v{}",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    // Create the server
+    let server = RetroChatMcpServer::new().await.map_err(|e| {
+        tracing::error!("Failed to initialize server: {}", e);
+        e
+    })?;
+
+    tracing::info!("Server initialized successfully");
+
+    // Start serving with stdio transport
+    let service = server.serve(stdio()).await.map_err(|e| {
+        tracing::error!("Failed to start server: {}", e);
+        e
+    })?;
+
+    tracing::info!("MCP server running on stdio transport");
+
+    // Wait for the service to complete
+    service.waiting().await.map_err(|e| {
+        tracing::error!("Server error: {}", e);
+        e
+    })?;
+
+    tracing::info!("Server shutting down gracefully");
+
+    Ok(())
+}

--- a/crates/retrochat-mcp/src/server.rs
+++ b/crates/retrochat-mcp/src/server.rs
@@ -1,0 +1,444 @@
+//! MCP Server implementation for RetroChat
+
+use crate::error::{not_found_error, to_mcp_error, validation_error};
+use retrochat_core::database::DatabaseManager;
+use retrochat_core::services::{
+    DateRange, QueryService, SearchRequest, SessionDetailRequest, SessionFilters,
+    SessionsQueryRequest,
+};
+use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::{tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// RetroChat MCP Server
+///
+/// Provides read-only access to chat session data and analytics
+/// through the Model Context Protocol.
+#[derive(Clone)]
+pub struct RetroChatMcpServer {
+    pub(crate) db_manager: Arc<DatabaseManager>,
+    pub(crate) tool_router: ToolRouter<Self>,
+}
+
+impl RetroChatMcpServer {
+    /// Get the query service (creates fresh instance)
+    pub(crate) fn query_service(&self) -> QueryService {
+        QueryService::with_database(self.db_manager.clone())
+    }
+
+    /// Create a new MCP server with default database
+    pub async fn new() -> anyhow::Result<Self> {
+        let db_path = retrochat_core::database::config::get_default_db_path()?;
+        let db_manager = Arc::new(DatabaseManager::new(&db_path).await?);
+
+        Ok(Self {
+            db_manager,
+            tool_router: Self::tool_router(),
+        })
+    }
+
+    /// Create a new MCP server with a specific database (for testing)
+    pub async fn with_database(db_manager: Arc<DatabaseManager>) -> Self {
+        Self {
+            db_manager,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+// Implement the ServerHandler trait
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for RetroChatMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            server_info: rmcp::model::Implementation {
+                name: "retrochat-mcp".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                title: Some("RetroChat MCP Server".into()),
+                website_url: None,
+                icons: None,
+            },
+            instructions: Some(
+                "RetroChat MCP Server - Query and analyze your AI chat history. \
+                 Use list_sessions to browse sessions, get_session_detail for full session info, \
+                 search_messages for full-text search, and get_session_analytics for analytics data."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_server_initialization() {
+        let db_manager = Arc::new(DatabaseManager::open_in_memory().await.unwrap());
+        let _server = RetroChatMcpServer::with_database(db_manager.clone()).await;
+
+        // Verify shared database manager
+        assert!(Arc::strong_count(&db_manager) >= 2); // server + our reference
+    }
+
+    #[tokio::test]
+    async fn test_server_info() {
+        let db_manager = Arc::new(DatabaseManager::open_in_memory().await.unwrap());
+        let server = RetroChatMcpServer::with_database(db_manager).await;
+        let info = server.get_info();
+
+        assert_eq!(info.server_info.name, "retrochat-mcp");
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
+        assert!(info.instructions.is_some());
+        assert!(info.instructions.unwrap().contains("RetroChat MCP Server"));
+        assert!(info.capabilities.tools.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_server_clone() {
+        let db_manager = Arc::new(DatabaseManager::open_in_memory().await.unwrap());
+        let server = RetroChatMcpServer::with_database(db_manager.clone()).await;
+        let cloned = server.clone();
+
+        // Both should share the same database manager
+        assert!(Arc::ptr_eq(&server.db_manager, &cloned.db_manager));
+    }
+
+    #[tokio::test]
+    async fn test_server_capabilities() {
+        let db_manager = Arc::new(DatabaseManager::open_in_memory().await.unwrap());
+        let server = RetroChatMcpServer::with_database(db_manager).await;
+        let info = server.get_info();
+
+        assert!(info.capabilities.tools.is_some());
+        // Read-only server - no prompts, resources, or sampling
+        assert!(info.capabilities.prompts.is_none());
+        assert!(info.capabilities.resources.is_none());
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ListSessionsParams {
+    /// Filter by provider (e.g., "Claude Code", "Gemini CLI")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+
+    /// Filter by project name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+
+    /// Filter sessions from this date (ISO 8601 format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+
+    /// Filter sessions until this date (ISO 8601 format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+
+    /// Minimum message count
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_messages: Option<i32>,
+
+    /// Maximum message count
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<i32>,
+
+    /// Page number (default: 1)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<i32>,
+
+    /// Items per page (default: 20)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<i32>,
+
+    /// Sort field (default: "start_time")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_by: Option<String>,
+
+    /// Sort order: "asc" or "desc" (default: "desc")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_order: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GetSessionDetailParams {
+    /// Session ID (UUID format)
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SearchMessagesParams {
+    /// Search query string
+    pub query: String,
+
+    /// Filter by providers (e.g., ["Claude Code", "Gemini CLI"])
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub providers: Option<Vec<String>>,
+
+    /// Filter by projects
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projects: Option<Vec<String>>,
+
+    /// Search from this date (ISO 8601 format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+
+    /// Search until this date (ISO 8601 format)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+
+    /// Page number (default: 1)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<i32>,
+
+    /// Items per page (default: 20)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GetSessionAnalyticsParams {
+    /// Session ID (UUID format)
+    pub session_id: String,
+}
+
+// ============================================================================
+// Tool Implementations
+// ============================================================================
+
+#[tool_router(router = tool_router)]
+impl RetroChatMcpServer {
+    /// List chat sessions with optional filtering and pagination
+    #[tool(
+        description = "List chat sessions with optional filtering by provider, project, date range, message count, and pagination support"
+    )]
+    pub async fn list_sessions(
+        &self,
+        params: Parameters<ListSessionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let params = params.0;
+
+        // Validate dates
+        if let Some(ref start) = params.start_date {
+            chrono::DateTime::parse_from_rfc3339(start)
+                .map_err(|_| validation_error(&format!("Invalid start_date format: {}", start)))?;
+        }
+        if let Some(ref end) = params.end_date {
+            chrono::DateTime::parse_from_rfc3339(end)
+                .map_err(|_| validation_error(&format!("Invalid end_date format: {}", end)))?;
+        }
+        if let Some(ref order) = params.sort_order {
+            if order != "asc" && order != "desc" {
+                return Err(validation_error(&format!(
+                    "Invalid sort_order: {}. Must be 'asc' or 'desc'",
+                    order
+                )));
+            }
+        }
+
+        // Build request
+        let date_range = match (&params.start_date, &params.end_date) {
+            (Some(start), Some(end)) => Some(DateRange {
+                start_date: start.clone(),
+                end_date: end.clone(),
+            }),
+            _ => None,
+        };
+
+        let filters = if params.provider.is_some()
+            || params.project.is_some()
+            || date_range.is_some()
+            || params.min_messages.is_some()
+            || params.max_messages.is_some()
+        {
+            Some(SessionFilters {
+                provider: params.provider,
+                project: params.project,
+                date_range,
+                min_messages: params.min_messages,
+                max_messages: params.max_messages,
+            })
+        } else {
+            None
+        };
+
+        let request = SessionsQueryRequest {
+            page: params.page,
+            page_size: params.page_size,
+            sort_by: params.sort_by,
+            sort_order: params.sort_order,
+            filters,
+        };
+
+        // Query sessions
+        let response = self
+            .query_service()
+            .query_sessions(request)
+            .await
+            .map_err(to_mcp_error)?;
+
+        // Return pretty-printed JSON
+        let json = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Get detailed information about a specific chat session including all messages
+    #[tool(
+        description = "Get detailed information about a specific chat session including all messages, tool usage, and metadata"
+    )]
+    pub async fn get_session_detail(
+        &self,
+        params: Parameters<GetSessionDetailParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let params = params.0;
+
+        // Validate UUID format
+        Uuid::parse_str(&params.session_id).map_err(|_| {
+            validation_error(&format!(
+                "Invalid session_id format: {}. Must be a valid UUID",
+                params.session_id
+            ))
+        })?;
+
+        // Create request
+        let request = SessionDetailRequest {
+            session_id: params.session_id.clone(),
+            include_content: Some(true),
+            message_limit: None,
+            message_offset: None,
+        };
+
+        // Get session detail
+        let response = self
+            .query_service()
+            .get_session_detail(request)
+            .await
+            .map_err(|e| {
+                let err_msg = e.to_string();
+                if err_msg.contains("not found") || err_msg.contains("Session not found") {
+                    not_found_error(&params.session_id)
+                } else {
+                    to_mcp_error(e)
+                }
+            })?;
+
+        // Return pretty-printed JSON
+        let json = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Full-text search across all messages in chat sessions
+    #[tool(
+        description = "Search for messages across all chat sessions using full-text search. Supports filtering by providers, projects, and date ranges"
+    )]
+    pub async fn search_messages(
+        &self,
+        params: Parameters<SearchMessagesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let params = params.0;
+
+        // Validate query
+        if params.query.trim().is_empty() {
+            return Err(validation_error("Search query cannot be empty"));
+        }
+
+        // Validate dates
+        if let Some(ref start) = params.start_date {
+            chrono::DateTime::parse_from_rfc3339(start)
+                .map_err(|_| validation_error(&format!("Invalid start_date format: {}", start)))?;
+        }
+        if let Some(ref end) = params.end_date {
+            chrono::DateTime::parse_from_rfc3339(end)
+                .map_err(|_| validation_error(&format!("Invalid end_date format: {}", end)))?;
+        }
+
+        // Build request
+        let date_range = match (&params.start_date, &params.end_date) {
+            (Some(start), Some(end)) => Some(DateRange {
+                start_date: start.clone(),
+                end_date: end.clone(),
+            }),
+            _ => None,
+        };
+
+        let request = SearchRequest {
+            query: params.query,
+            providers: params.providers,
+            projects: params.projects,
+            date_range,
+            search_type: None,
+            page: params.page,
+            page_size: params.page_size,
+        };
+
+        // Search messages
+        let response = self
+            .query_service()
+            .search_messages(request)
+            .await
+            .map_err(to_mcp_error)?;
+
+        // Return pretty-printed JSON
+        let json = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Get analytics information for a specific chat session
+    #[tool(
+        description = "Get analytics information for a specific chat session, including completed analytics results and any pending/running analysis requests"
+    )]
+    pub async fn get_session_analytics(
+        &self,
+        params: Parameters<GetSessionAnalyticsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let params = params.0;
+
+        // Validate UUID format
+        Uuid::parse_str(&params.session_id).map_err(|_| {
+            validation_error(&format!(
+                "Invalid session_id format: {}. Must be a valid UUID",
+                params.session_id
+            ))
+        })?;
+
+        // Get session analytics
+        let response = self
+            .query_service()
+            .get_session_analytics(&params.session_id)
+            .await
+            .map_err(|e| {
+                let err_msg = e.to_string();
+                if err_msg.contains("not found") || err_msg.contains("Session not found") {
+                    not_found_error(&params.session_id)
+                } else {
+                    to_mcp_error(e)
+                }
+            })?;
+
+        // Manually construct JSON since SessionAnalytics doesn't implement Serialize
+        let json = if let Some(analytics) = response {
+            let value = serde_json::json!({
+                "latest_analytics": analytics.latest_analytics,
+                "latest_request": analytics.latest_request,
+                "active_request": analytics.active_request,
+            });
+            serde_json::to_string_pretty(&value)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        } else {
+            "null".to_string()
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+}


### PR DESCRIPTION
## Summary

Add `retrochat-mcp` crate that exposes chat session query and analytics capabilities via Model Context Protocol (MCP). This enables AI assistants like Claude and Cursor to query and analyze chat history.

## Features

- **Read-only MCP server** with stdio transport
- **4 MCP tools**:
  - `list_sessions` - Query and filter chat sessions with pagination
  - `get_session_detail` - Get full session details with all messages  
  - `search_messages` - Full-text search across all messages
  - `get_session_analytics` - Get analytics for a session
- Comprehensive error handling and validation (UUID, dates)
- Pretty-printed JSON responses for easy AI consumption
- Unit tests for all components (9 tests passing)
- Documentation in CLAUDE.md with configuration examples

## Technical Details

- Uses `rmcp` 0.11 with server, macros, and transport-io features
- Shares database with CLI/TUI (read-only access)
- Logs to stderr to avoid interfering with stdio transport
- Supports `RUST_LOG` environment variable for log level control

## Usage

```bash
# Run MCP server
cargo mcp

# Run tests
cargo tmcp

# With debug logging
RUST_LOG=debug cargo mcp
```

## Configuration

**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
```json
{
  "mcpServers": {
    "retrochat": {
      "command": "/path/to/retrochat-mcp",
      "args": []
    }
  }
}
```

**Cursor** (`.cursor/mcp.json`):
```json
{
  "mcpServers": {
    "retrochat": {
      "command": "cargo",
      "args": ["run", "-p", "retrochat-mcp"],
      "cwd": "/path/to/retrochat"
    }
  }
}
```

## Testing

- All unit tests passing (9/9)
- Clippy clean with `-D warnings`
- Release build successful
- Formatted with `cargo fmt`

## Files Changed

- Added `crates/retrochat-mcp/` crate (5 files, 813 lines)
- Updated workspace `Cargo.toml` with new member and dependencies
- Updated `.cargo/config.toml` with `mcp` and `tmcp` aliases
- Updated `CLAUDE.md` with comprehensive MCP server documentation