### PR TITLE
feat: add SlashCommand message type for Claude Code command blocks

### DIFF
--- a/.sqlx/query-16d83cb7e55768d51a99ae240dac3d305c7696877b7d1126269dadc2166ff712.json
+++ b/.sqlx/query-16d83cb7e55768d51a99ae240dac3d305c7696877b7d1126269dadc2166ff712.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT session_id FROM analytics_requests WHERE id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "session_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "16d83cb7e55768d51a99ae240dac3d305c7696877b7d1126269dadc2166ff712"
+}

--- a/.sqlx/query-1f8ef75ee4ce329f878ad852323147d541ee8f69506fbc36386ea34a5c9f6da8.json
+++ b/.sqlx/query-1f8ef75ee4ce329f878ad852323147d541ee8f69506fbc36386ea34a5c9f6da8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO analytics (\n                id, analytics_request_id, session_id, generated_at,\n                qualitative_output_json,\n                ai_quantitative_output_json,\n                metric_quantitative_output_json,\n                model_used, analysis_duration_ms\n            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 9
+    },
+    "nullable": []
+  },
+  "hash": "1f8ef75ee4ce329f878ad852323147d541ee8f69506fbc36386ea34a5c9f6da8"
+}

--- a/.sqlx/query-52ec7d328d2f43ace95296caa380aeac9b75704263ada069cb87c6faa6cb4a7d.json
+++ b/.sqlx/query-52ec7d328d2f43ace95296caa380aeac9b75704263ada069cb87c6faa6cb4a7d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO analytics_requests (\n                id, session_id, status, started_at, completed_at,\n                created_by, error_message, custom_prompt\n            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": []
+  },
+  "hash": "52ec7d328d2f43ace95296caa380aeac9b75704263ada069cb87c6faa6cb4a7d"
+}

--- a/.sqlx/query-70b55d0a9faf7bea3ba229c92f5e6f81107d887d43ca950bd85c7a7081cd96fa.json
+++ b/.sqlx/query-70b55d0a9faf7bea3ba229c92f5e6f81107d887d43ca950bd85c7a7081cd96fa.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as count FROM analytics_requests WHERE status = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Int"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "70b55d0a9faf7bea3ba229c92f5e6f81107d887d43ca950bd85c7a7081cd96fa"
+}

--- a/.sqlx/query-76fa1a7b667a1c5a8e5cbb355261cb716bc1f40e8035eec1289702a2287e574a.json
+++ b/.sqlx/query-76fa1a7b667a1c5a8e5cbb355261cb716bc1f40e8035eec1289702a2287e574a.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id, analytics_request_id, session_id, generated_at,\n                qualitative_output_json,\n                ai_quantitative_output_json,\n                metric_quantitative_output_json,\n                model_used, analysis_duration_ms\n            FROM analytics\n            WHERE analytics_request_id = ?\n            ORDER BY generated_at DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "analytics_request_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "generated_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "qualitative_output_json",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "ai_quantitative_output_json",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "metric_quantitative_output_json",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "model_used",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "analysis_duration_ms",
+        "ordinal": 8,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "76fa1a7b667a1c5a8e5cbb355261cb716bc1f40e8035eec1289702a2287e574a"
+}

--- a/.sqlx/query-85e79f8bee1545849066899470728dac9d6f71b720b2488ab112584e0ee19a03.json
+++ b/.sqlx/query-85e79f8bee1545849066899470728dac9d6f71b720b2488ab112584e0ee19a03.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as count FROM analytics_requests WHERE status IN ('pending', 'running')",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Int"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "85e79f8bee1545849066899470728dac9d6f71b720b2488ab112584e0ee19a03"
+}

--- a/.sqlx/query-a3a2bf6d2877a712b961a3dfc1d732b85a27cf0f1453e86ede0e179608f5830c.json
+++ b/.sqlx/query-a3a2bf6d2877a712b961a3dfc1d732b85a27cf0f1453e86ede0e179608f5830c.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE status = ? ORDER BY started_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "a3a2bf6d2877a712b961a3dfc1d732b85a27cf0f1453e86ede0e179608f5830c"
+}

--- a/.sqlx/query-a60c6fbf087d65237d635258999d4357ba7381aafb7b0efc8aefd8727ac7e786.json
+++ b/.sqlx/query-a60c6fbf087d65237d635258999d4357ba7381aafb7b0efc8aefd8727ac7e786.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE started_at >= ? ORDER BY started_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "a60c6fbf087d65237d635258999d4357ba7381aafb7b0efc8aefd8727ac7e786"
+}

--- a/.sqlx/query-abf269f1fdf77d92aeb10e953fa8f5278519ddb5f70b25b2a0c48231add2bace.json
+++ b/.sqlx/query-abf269f1fdf77d92aeb10e953fa8f5278519ddb5f70b25b2a0c48231add2bace.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests ORDER BY started_at DESC LIMIT ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "abf269f1fdf77d92aeb10e953fa8f5278519ddb5f70b25b2a0c48231add2bace"
+}

--- a/.sqlx/query-b090411c4cb1bd288c5f024dbb7cb87bd624a286ee2e4efdd2932937ea3ce63f.json
+++ b/.sqlx/query-b090411c4cb1bd288c5f024dbb7cb87bd624a286ee2e4efdd2932937ea3ce63f.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "b090411c4cb1bd288c5f024dbb7cb87bd624a286ee2e4efdd2932937ea3ce63f"
+}

--- a/.sqlx/query-b9301b4ad8601f33efc34fa29d2da353b93e6c0002f1ea5eaec6937fc93486ad.json
+++ b/.sqlx/query-b9301b4ad8601f33efc34fa29d2da353b93e6c0002f1ea5eaec6937fc93486ad.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE created_by = ? ORDER BY started_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "b9301b4ad8601f33efc34fa29d2da353b93e6c0002f1ea5eaec6937fc93486ad"
+}

--- a/.sqlx/query-cc2b8d306223e34b8105cf775d9b14c366b42454be105f69933e49287d2728db.json
+++ b/.sqlx/query-cc2b8d306223e34b8105cf775d9b14c366b42454be105f69933e49287d2728db.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE status IN ('pending', 'running') ORDER BY started_at ASC",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "cc2b8d306223e34b8105cf775d9b14c366b42454be105f69933e49287d2728db"
+}

--- a/.sqlx/query-e09e456b7afa3cf68557e2daa8cfb499f84b7a13b2eb745c468e38a8f35ec58c.json
+++ b/.sqlx/query-e09e456b7afa3cf68557e2daa8cfb499f84b7a13b2eb745c468e38a8f35ec58c.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM analytics_requests WHERE session_id = ? ORDER BY started_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "status",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "started_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_by",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "error_message",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "custom_prompt",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "e09e456b7afa3cf68557e2daa8cfb499f84b7a13b2eb745c468e38a8f35ec58c"
+}

--- a/.sqlx/query-f64b389d270e02d0d2111c50691ebb2209038b90dafd66a4e5d59b5b7c3b4746.json
+++ b/.sqlx/query-f64b389d270e02d0d2111c50691ebb2209038b90dafd66a4e5d59b5b7c3b4746.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM analytics_requests WHERE completed_at IS NOT NULL AND completed_at < ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "f64b389d270e02d0d2111c50691ebb2209038b90dafd66a4e5d59b5b7c3b4746"
+}

--- a/.sqlx/query-fa1149b5d14759d111418649428d7779bf47c7d24a2150b8cdcf025f15482b98.json
+++ b/.sqlx/query-fa1149b5d14759d111418649428d7779bf47c7d24a2150b8cdcf025f15482b98.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM analytics_requests WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "fa1149b5d14759d111418649428d7779bf47c7d24a2150b8cdcf025f15482b98"
+}

--- a/.sqlx/query-fc4e5e50bba17e73854cd3e68d50b0815935788644dc0ef54ea7f872cd3d73ce.json
+++ b/.sqlx/query-fc4e5e50bba17e73854cd3e68d50b0815935788644dc0ef54ea7f872cd3d73ce.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id, analytics_request_id, session_id, generated_at,\n                qualitative_output_json,\n                ai_quantitative_output_json,\n                metric_quantitative_output_json,\n                model_used, analysis_duration_ms\n            FROM analytics\n            WHERE id = ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "analytics_request_id",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "session_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "generated_at",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "qualitative_output_json",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "ai_quantitative_output_json",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "metric_quantitative_output_json",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "model_used",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "analysis_duration_ms",
+        "ordinal": 8,
+        "type_info": "Int64"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "fc4e5e50bba17e73854cd3e68d50b0815935788644dc0ef54ea7f872cd3d73ce"
+}

--- a/crates/retrochat-core/migrations/017_add_slash_command_message_type.sql
+++ b/crates/retrochat-core/migrations/017_add_slash_command_message_type.sql
@@ -1,0 +1,69 @@
+-- Add slash_command message type
+-- Migration: 017_add_slash_command_message_type
+-- Description: Add 'slash_command' to message_type CHECK constraint to support Claude Code slash command messages
+
+-- Drop the old constraint and add the new one with 'slash_command'
+-- SQLite doesn't support ALTER TABLE ... DROP CONSTRAINT, so we need to recreate the table
+
+-- Create a temporary table with the new schema
+CREATE TABLE messages_new (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('User', 'Assistant', 'System')),
+    content TEXT NOT NULL CHECK (length(content) > 0),
+    timestamp TEXT NOT NULL,
+    token_count INTEGER CHECK (token_count >= 0),
+    metadata TEXT,   -- JSON object
+    sequence_number INTEGER NOT NULL,
+    message_type TEXT NOT NULL DEFAULT 'simple_message' CHECK (message_type IN ('tool_request', 'tool_result', 'thinking', 'slash_command', 'simple_message')),
+    tool_operation_id TEXT,
+    FOREIGN KEY (session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (tool_operation_id) REFERENCES tool_operations(id) ON DELETE SET NULL,
+    UNIQUE(session_id, sequence_number)
+);
+
+-- Copy data from old table
+INSERT INTO messages_new (id, session_id, role, content, timestamp, token_count, metadata, sequence_number, message_type, tool_operation_id)
+SELECT id, session_id, role, content, timestamp, token_count, metadata, sequence_number, message_type, tool_operation_id
+FROM messages;
+
+-- Drop old table
+DROP TABLE messages;
+
+-- Rename new table to messages
+ALTER TABLE messages_new RENAME TO messages;
+
+-- Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role);
+CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_sequence ON messages(session_id, sequence_number);
+CREATE INDEX IF NOT EXISTS idx_messages_message_type ON messages(message_type);
+CREATE INDEX IF NOT EXISTS idx_messages_tool_operation ON messages(tool_operation_id);
+
+-- Rebuild FTS index after table recreation
+-- First, delete and recreate the FTS table
+DROP TABLE IF EXISTS messages_fts;
+
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    content,
+    session_id UNINDEXED,
+    role UNINDEXED,
+    timestamp UNINDEXED,
+    content='messages',
+    content_rowid='rowid'
+);
+
+-- Recreate FTS triggers
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (NEW.rowid, NEW.content);
+END;
+
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', OLD.rowid, OLD.content);
+END;
+
+CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', OLD.rowid, OLD.content);
+    INSERT INTO messages_fts(rowid, content) VALUES (NEW.rowid, NEW.content);
+END;

--- a/crates/retrochat-core/src/models/message.rs
+++ b/crates/retrochat-core/src/models/message.rs
@@ -15,8 +15,22 @@ pub enum MessageType {
     ToolRequest,
     ToolResult,
     Thinking,
+    SlashCommand,
     #[default]
     SimpleMessage,
+}
+
+/// Parsed slash command from XML blocks (e.g., /clear, /help)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlashCommandData {
+    /// The command name (e.g., "/clear", "/help")
+    pub command_name: String,
+    /// The command message/description
+    pub command_message: Option<String>,
+    /// Command arguments if any
+    pub command_args: Option<String>,
+    /// Command stdout result
+    pub stdout: Option<String>,
 }
 
 impl std::fmt::Display for MessageRole {
@@ -48,6 +62,7 @@ impl std::fmt::Display for MessageType {
             MessageType::ToolRequest => write!(f, "tool_request"),
             MessageType::ToolResult => write!(f, "tool_result"),
             MessageType::Thinking => write!(f, "thinking"),
+            MessageType::SlashCommand => write!(f, "slash_command"),
             MessageType::SimpleMessage => write!(f, "simple_message"),
         }
     }
@@ -61,6 +76,7 @@ impl std::str::FromStr for MessageType {
             "tool_request" => Ok(MessageType::ToolRequest),
             "tool_result" => Ok(MessageType::ToolResult),
             "thinking" => Ok(MessageType::Thinking),
+            "slash_command" => Ok(MessageType::SlashCommand),
             "simple_message" => Ok(MessageType::SimpleMessage),
             _ => Err(format!("Unknown message type: {s}")),
         }
@@ -217,6 +233,11 @@ impl Message {
     /// Check if this message is thinking
     pub fn is_thinking(&self) -> bool {
         matches!(self.message_type, MessageType::Thinking)
+    }
+
+    /// Check if this message is a slash command
+    pub fn is_slash_command(&self) -> bool {
+        matches!(self.message_type, MessageType::SlashCommand)
     }
 
     /// Check if this message has an associated tool operation

--- a/crates/retrochat-core/src/services/analytics/data_collector.rs
+++ b/crates/retrochat-core/src/services/analytics/data_collector.rs
@@ -143,6 +143,7 @@ fn get_message_type_string(
             format!("tool_result({})", tool_name)
         }
         MessageType::Thinking => "thinking".to_string(),
+        MessageType::SlashCommand => "slash_command".to_string(),
         MessageType::SimpleMessage => "simple_message".to_string(),
     }
 }

--- a/crates/retrochat-core/src/services/query_service.rs
+++ b/crates/retrochat-core/src/services/query_service.rs
@@ -13,11 +13,11 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 pub enum MessageGroup {
     /// A single standalone message
-    Single(Message),
+    Single(Box<Message>),
     /// A tool use message paired with its corresponding tool result message
     ToolPair {
-        tool_use_message: Message,
-        tool_result_message: Message,
+        tool_use_message: Box<Message>,
+        tool_result_message: Box<Message>,
     },
 }
 
@@ -70,8 +70,8 @@ impl MessageGroup {
                         if has_matching_result {
                             // Create a ToolPair and skip the next message
                             groups.push(MessageGroup::ToolPair {
-                                tool_use_message: current.clone(),
-                                tool_result_message: next.clone(),
+                                tool_use_message: Box::new(current.clone()),
+                                tool_result_message: Box::new(next.clone()),
                             });
                             i += 2; // Skip both messages
                             continue;
@@ -81,7 +81,7 @@ impl MessageGroup {
             }
 
             // Not a pair, add as single
-            groups.push(MessageGroup::Single(current.clone()));
+            groups.push(MessageGroup::Single(Box::new(current.clone())));
             i += 1;
         }
 

--- a/crates/retrochat-tui/src/session_detail.rs
+++ b/crates/retrochat-tui/src/session_detail.rs
@@ -352,8 +352,9 @@ impl SessionDetailWidget {
 
     /// Renders a single message block
     fn render_message_block(&self, message: &Message, width: usize, lines: &mut Vec<Line<'_>>) {
-        // Check if this is a thinking message
+        // Check message types
         let is_thinking = message.is_thinking();
+        let is_slash_command = message.is_slash_command();
 
         // Message header
         let role_style = if is_thinking {
@@ -361,6 +362,11 @@ impl SessionDetailWidget {
             Style::default()
                 .fg(Color::Magenta)
                 .add_modifier(Modifier::BOLD | Modifier::ITALIC)
+        } else if is_slash_command {
+            // Slash command messages have yellow/amber styling
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
         } else {
             match message.role {
                 MessageRole::User => Style::default()
@@ -378,6 +384,8 @@ impl SessionDetailWidget {
         let timestamp = &message.timestamp.format("%H:%M:%S").to_string(); // Just show time
         let header = if is_thinking {
             format!("[{timestamp}] Thinking")
+        } else if is_slash_command {
+            format!("[{timestamp}] Slash Command")
         } else {
             format!("[{timestamp}] {:?}", message.role)
         };
@@ -390,11 +398,13 @@ impl SessionDetailWidget {
         // Message content - wrap text and preserve newlines
         let content_lines = wrap_text(&message.content, width.saturating_sub(2));
 
-        // Use different styling for thinking content
+        // Use different styling for thinking and slash command content
         let content_style = if is_thinking {
             Style::default()
                 .fg(Color::Rgb(180, 140, 200)) // Light purple for thinking
                 .add_modifier(Modifier::ITALIC)
+        } else if is_slash_command {
+            Style::default().fg(Color::Rgb(200, 180, 100)) // Golden/amber for slash commands
         } else {
             Style::default().fg(Color::White)
         };

--- a/ui-react/src/components/session-detail.tsx
+++ b/ui-react/src/components/session-detail.tsx
@@ -6,7 +6,16 @@ import {
   ReloadIcon,
 } from '@radix-ui/react-icons'
 import { format, formatDistanceToNow } from 'date-fns'
-import { Bot, Brain, Check, Copy, FileCode, MessageSquare, TrendingUp } from 'lucide-react'
+import {
+  Bot,
+  Brain,
+  Check,
+  Copy,
+  FileCode,
+  MessageSquare,
+  Terminal,
+  TrendingUp,
+} from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import ReactMarkdown from 'react-markdown'
@@ -149,6 +158,10 @@ function MessageRenderer({ message }: { message: SessionWithMessages['messages']
     return <ToolResultMessage message={message} />
   }
 
+  if (messageType === 'slash_command') {
+    return <SlashCommandMessage message={message} />
+  }
+
   return <SimpleMessage message={message} />
 }
 
@@ -183,6 +196,57 @@ function ThinkingMessage({ message }: { message: SessionWithMessages['messages']
             <CollapsibleContent className="mt-2">
               <div className="rounded-lg p-4 bg-card border border-border text-card-foreground">
                 <p className="whitespace-pre-wrap leading-relaxed text-sm text-muted-foreground italic">
+                  {message.content}
+                </p>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SlashCommandMessage({ message }: { message: SessionWithMessages['messages'][0] }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  // Extract command name from content if available
+  const commandName =
+    message.content.match(/\[Slash Command: (.*?)\]/)?.[1] ||
+    message.content.match(/<command-name>(.*?)<\/command-name>/)?.[1] ||
+    'Command'
+
+  return (
+    <div className="flex gap-4 justify-start">
+      <div className="flex gap-3 max-w-[80%]">
+        <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+          <Terminal className="w-4 h-4" />
+        </div>
+        <div className="flex flex-col items-start flex-1">
+          <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-between p-3 h-auto bg-yellow-500/5 hover:bg-yellow-500/10 border border-yellow-500/20 rounded-lg"
+              >
+                <div className="flex items-center gap-2">
+                  <Terminal className="w-4 h-4 text-yellow-400" />
+                  <span className="text-sm font-medium text-yellow-300">{commandName}</span>
+                  <Badge variant="outline" className="text-xs border-yellow-500/30 text-yellow-400">
+                    Local
+                  </Badge>
+                </div>
+                <ChevronDownIcon
+                  className={`w-4 h-4 text-yellow-400 transition-transform ${
+                    isOpen ? 'rotate-180' : ''
+                  }`}
+                />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-2">
+              <div className="rounded-lg p-4 bg-card border border-border text-card-foreground">
+                <p className="whitespace-pre-wrap leading-relaxed text-sm text-muted-foreground">
                   {message.content}
                 </p>
               </div>


### PR DESCRIPTION
## Summary

Add support for parsing and displaying XML command blocks from Claude Code JSONL files (e.g., `/clear`, `/help`, `/model` commands).

## Changes

- Add `SlashCommand` variant to `MessageType` enum with `SlashCommandData` struct
- Add regex parsing in `claude_code.rs` for XML command blocks:
  - `<command-name>`, `<command-message>`, `<command-args>`, `<local-command-stdout>`
- Add database migration 017 to include `slash_command` in CHECK constraint
- Add yellow/amber styling in TUI for slash command messages
- Add `SlashCommandMessage` component in React GUI with Terminal icon
- Add 8 unit tests for slash command parsing and MessageType serialization
- Fix clippy `large_enum_variant` warning by boxing `MessageGroup` fields

## Test Plan

- [x] All existing tests pass (`cargo t`)
- [x] New slash command tests pass
- [x] Clippy passes with `-D warnings`
- [x] SQLx prepared queries updated
- [x] React code formatted with Biome

🤖 Generated with [Claude Code](https://claude.com/claude-code)